### PR TITLE
Fix compilation warnings.

### DIFF
--- a/src/GblData.cpp
+++ b/src/GblData.cpp
@@ -149,7 +149,8 @@ double GblData::getChi2() const {
 /// Print data block.
 void GblData::printData() const {
 
-	std::cout << " measurement at label " << theLabel << " of type " << theType
+	std::cout << " measurement at label " << theLabel << " of type "
+                  << static_cast<int>(theType)
 			<< " from row " << theRow << ": " << theValue << ", "
 			<< thePrecision << std::endl;
 	std::cout << "  param " << moreParameters.size() + theNumLocal << ":";


### PR DESCRIPTION

Fix some compilation warnings seen with recent compilers.
 - -Wsign-promo warnings arising from giving an enum to operator<<.